### PR TITLE
Update  qmlsqlintegration/chat.qml

### DIFF
--- a/sources/pyside6/doc/tutorials/qmlsqlintegration/chat.qml
+++ b/sources/pyside6/doc/tutorials/qmlsqlintegration/chat.qml
@@ -54,7 +54,7 @@ ApplicationWindow {
     }
 
     ColumnLayout {
-        anchors.fill: window
+        anchors.fill: parent
 
         ListView {
             id: listView

--- a/sources/pyside6/doc/tutorials/qmlsqlintegration/chat.qml
+++ b/sources/pyside6/doc/tutorials/qmlsqlintegration/chat.qml
@@ -101,6 +101,8 @@ ApplicationWindow {
                     anchors.right: sentByMe ? parent.right : undefined
                 }
             }
+            
+            
         }
 
         Pane {

--- a/sources/pyside6/doc/tutorials/qmlsqlintegration/chat.qml
+++ b/sources/pyside6/doc/tutorials/qmlsqlintegration/chat.qml
@@ -101,8 +101,6 @@ ApplicationWindow {
                     anchors.right: sentByMe ? parent.right : undefined
                 }
             }
-
-            ScrollBar.vertical: ScrollBar {}
         }
 
         Pane {


### PR DESCRIPTION
I used pyside6 under windows. When testing this case, I found that if the current 'window' will cause the whole interface to shrink into a ball and cannot see the complete interface. Changing to 'parent' can solve this problem.